### PR TITLE
Standardise INFO box titles to ## heading

### DIFF
--- a/en/step_3.md
+++ b/en/step_3.md
@@ -34,7 +34,7 @@ Try changing `'hello world'` to a different message. Make sure you use `'` aroun
 
 > [!INFO]
 >
-> ### What is Atbash?
+> ## What is Atbash?
 >
 > - Atbash makes the secret code
 > - It uses the swapped letters from the dictionary to create new words

--- a/en/step_5.md
+++ b/en/step_5.md
@@ -46,7 +46,7 @@ gsrh rh olmtvi gvcg
 
 > [!INFO]
 >
-> ### Code explainer
+> ## Code explainer
 >
 > - This uses `choice` in a loop. The loop runs until the user enters `e` or `f`.
 > - If the user enters `e`, the message is encoded.


### PR DESCRIPTION
Small consistency fix: box titles inside callouts use level-2 headings.

- step_3 "What is Atbash?" and step_5 "Code explainer": `> ### Title` → `> ## Title`

Matches the standardised box-title rule (titles inside `[!INFO]`/`[!CHALLENGE]` boxes are `## Title`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)